### PR TITLE
♻️ refactor: wordziplogic

### DIFF
--- a/src/words/words.controller.ts
+++ b/src/words/words.controller.ts
@@ -21,9 +21,9 @@ export class WordsController {
   @Post('/books')
   async createWordBook(@Request() req, @Body() body: { wordbook_title: string }) {
     try {
-      return await this.wordsService.createWordBook(req.user, body.wordbook_title);
+      return await this.wordsService.createWordBook(req.user.user_id, body.wordbook_title);
     } catch (error) {
-      throw new BadRequestException(error.message); // 🚨 400 에러 반환
+      throw new BadRequestException(error.message);
     }
   }
 

--- a/src/words/words.service.ts
+++ b/src/words/words.service.ts
@@ -15,6 +15,8 @@ export class WordsService {
     private wordMiddleRepository:Repository<WordMiddle>,
     @InjectRepository(WordBook)
     private wordBookRepository: Repository<WordBook>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
   ) {}
 
   // 🔥 단어 관련 비즈니스 로직
@@ -34,8 +36,13 @@ export class WordsService {
 
   // 🔥 단어장 관련 비즈니스 로직
   // ✅ 단어장 생성 로직
-  async createWordBook(user: User, wordbook_title: string): Promise<WordBook> {
+  async createWordBook(userId: number, wordbook_title: string): Promise<WordBook> {
     // ✅ 1. 같은 이름의 단어장이 있는지 검사
+    const user = await this.userRepository.findOne({ where: { user_id: userId } });
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+  
     const existingBook = await this.wordBookRepository.findOne({
       where: { user: { user_id: user.user_id }, wordbook_title },
     });


### PR DESCRIPTION
## 🔍 해결하려는 문제

로그인한 유저가 자신만의 단어장을 생성할 수 있는 기능을 구현함
프론트엔드에서 쿠키에 저장된 JWT 토큰을 파싱해 user_id를 추출한 뒤,
백엔드 API로 wordbook_title과 함께 전달하도록 구성함.

## ✨ 주요 변경 사항

1. 단어장 생성 API (POST /words/books) 연결
2. JWT 토큰을 쿠키에서 파싱해 user_id 추출
3. 입력된 단어장 이름과 함께 서버에 요청
4. 단어장 생성 후, 리스트를 다시 불러오도록 구현

## 🔖 추가 변경 사항

없음

## 🖥 작동하는 모습

단어장 생성 버튼 클릭 → 이름 입력 → 생성 완료 시 자동으로 리스트에 반영됨

## 📚 관련 문서

> 관련된 Issue, 문서, 또는 노션 링크가 있다면 첨부해주세요.
