### PR TITLE
⛑️ edit: user, qna entity edit

### DIFF
--- a/src/chatbot/entities/chatbot-qna.entity.ts
+++ b/src/chatbot/entities/chatbot-qna.entity.ts
@@ -23,6 +23,9 @@ export class ChatbotQna {
   kr_answer: string; // 전체 문장 (한국어 정답)
 
   @Column({ type: 'varchar', length: 255, nullable: false })
+  jp_answer: string; // 전체 문장 (일본어 정답)
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
   blank_answer: string; // 빈칸 포함된 문제 문장
 
   @Column({ type: 'json', nullable: false })

--- a/src/migrations/1742949315169-useruuid.ts
+++ b/src/migrations/1742949315169-useruuid.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Useruuid1742949315169 implements MigrationInterface {
+    name = 'Useruuid1742949315169'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`user\` ADD \`uuid\` varchar(36) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE \`user\` ADD UNIQUE INDEX \`IDX_a95e949168be7b7ece1a2382fe\` (\`uuid\`)`);
+        await queryRunner.query(`ALTER TABLE \`user\` CHANGE \`password\` \`password\` varchar(255) NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`user\` CHANGE \`password\` \`password\` varchar(255) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE \`user\` DROP INDEX \`IDX_a95e949168be7b7ece1a2382fe\``);
+        await queryRunner.query(`ALTER TABLE \`user\` DROP COLUMN \`uuid\``);
+    }
+
+}

--- a/src/migrations/1742949522011-qnajpanswer.ts
+++ b/src/migrations/1742949522011-qnajpanswer.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Qnajpanswer1742949522011 implements MigrationInterface {
+    name = 'Qnajpanswer1742949522011'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` ADD \`jp_answer\` varchar(255) NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` DROP COLUMN \`jp_answer\``);
+    }
+
+}

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, BeforeInsert } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
 import { WordBook } from '../../words/entities/word-books.entity';
 import { GrammarBook } from '../../grammars/entities/grammar-books.entity';
 import { QuizGame } from '../../quiz-game/entities/quiz-game.entity';
@@ -9,20 +10,25 @@ export class User {
   @PrimaryGeneratedColumn()
   user_id: number;
 
+  @Column({ type: 'varchar', length: 36, unique: true })
+  uuid: string;
+
+  @BeforeInsert()
+  generateUUID() {
+    this.uuid = uuidv4();
+  }
+
   @Column({ type: 'varchar', length: 30 })
   name: string;
 
   @Column({ type: 'varchar', length: 100, unique: true })
   email: string;
 
-  @Column({ type: 'varchar', length: 255 })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   password: string;
 
   @Column({ type: 'text', nullable: true })
   profile_image: string;
-
-  @Column({ type: 'int', nullable: true })
-  social_check: number;
 
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entity/user.entity';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  exports: [TypeOrmModule],
+})
 export class UserModule {}

--- a/src/words/words.module.ts
+++ b/src/words/words.module.ts
@@ -5,9 +5,13 @@ import { WordBook } from './entities/word-books.entity';
 import { WordMiddle } from './entities/word-middle.entity';
 import { WordsService } from './words.service';
 import { WordsController } from './words.controller';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Word, WordBook, WordMiddle])],
+  imports: [
+    TypeOrmModule.forFeature([Word, WordBook, WordMiddle]),
+    UserModule,
+  ],
   providers: [WordsService],
   controllers: [WordsController],
   exports: [WordsService],


### PR DESCRIPTION
## 🔍 해결하려는 문제
User 엔티티에 UUID 컬럼을 추가하고자 했지만, MySQL에서 DEFAULT UUID() 문법 오류 발생으로 마이그레이션 실패

## ✨ 주요 변경 사항
User 엔티티에서 UUID 컬럼 타입을 varchar(36)으로 수정
@BeforeInsert를 사용해 UUID를 코드에서 생성하도록 변경
기존 default: () => 'UUID()' 제거

## 🔖 추가 변경 사항

qun테이블 수정

## 🖥 작동하는 모습

작동확인

## 📚 관련 문서

없음
