### PR TITLE
⛑️ edit: chatbot_qnatable edit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
         "class-validator": "^0.14.1",
         "dotenv": "^16.4.7",
         "multer": "^1.4.5-lts.1",
-        "openai": "^4.0.0",
         "mysql2": "^3.13.0",
+        "openai": "^4.0.0",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
@@ -3356,6 +3356,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/multer": {
       "version": "1.4.12",
       "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
@@ -4450,7 +4456,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
       "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6319,15 +6324,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -6337,6 +6333,15 @@
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/events": {
@@ -6876,7 +6881,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -10501,8 +10505,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/src/chatbot/chatbot-qna.service.ts
+++ b/src/chatbot/chatbot-qna.service.ts
@@ -42,10 +42,12 @@ export class ChatQnAService {
 
     return questions.map(q => ({
       qna_id: q.qna_id,
-      chatbot_question: q.chatbot_question,
+      order_index: q.order_index,
+      jp_question: q.jp_question,
+      kr_question: q.kr_question,
+      jp_answer: q.jp_answer,
       kr_answer: q.kr_answer,
       blank_answer: q.blank_answer,
-      order_index: q.order_index,
       choices: q.choice_list,
     }));
   }

--- a/src/chatbot/chatbot.controller.ts
+++ b/src/chatbot/chatbot.controller.ts
@@ -69,9 +69,9 @@ export class ChatbotController {
   // ✅ 유저 입력값 검증 및 다음 단계 진행
   @Post('check-answer/:situationId/:orderIndex')
   async checkAnswer(
-    @Param('situationId') situationId: number, 
-    @Param('orderIndex') orderIndex: number,
-    @Body('selectedChoice') selectedChoice: string
+  @Param('situationId') situationId: number, 
+  @Param('orderIndex') orderIndex: number,
+  @Body('selectedChoice') selectedChoice: string
   ) {
     return await this.chatQnAService.checkAnswer(situationId, orderIndex, selectedChoice);
   }

--- a/src/chatbot/entities/chatbot-qna.entity.ts
+++ b/src/chatbot/entities/chatbot-qna.entity.ts
@@ -17,7 +17,10 @@ export class ChatbotQna {
   order_index: number; // 대화 순서 (ex. 1 -> 2 -> 3)
 
   @Column({ type: 'varchar', length: 255, nullable: false })
-  chatbot_question: string; // 챗봇이 질문하는 문장
+  jp_question: string; // 챗봇 질문 (일본어)
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  kr_question: string; // 챗봇 질문 해석 (한국어)
 
   @Column({ type: 'varchar', length: 255, nullable: false })
   kr_answer: string; // 전체 문장 (한국어 정답)

--- a/src/migrations/1742968632621-qnatableedit.ts
+++ b/src/migrations/1742968632621-qnatableedit.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Qnatableedit1742968632621 implements MigrationInterface {
+    name = 'Qnatableedit1742968632621'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` DROP COLUMN \`chatbot_question\``);
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` ADD \`jp_question\` varchar(255) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` ADD \`kr_question\` varchar(255) NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` DROP COLUMN \`kr_question\``);
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` DROP COLUMN \`jp_question\``);
+        await queryRunner.query(`ALTER TABLE \`chatbot_qna\` ADD \`chatbot_question\` varchar(255) NOT NULL`);
+    }
+
+}


### PR DESCRIPTION
## 🔍 해결하려는 문제

chatbot_qna 테이블 컬럼 정비에 따른 로직 수정

## ✨ 주요 변경 사항

chatbot_qna 테이블 컬럼 정비 (jp_question, kr_question, jp_answer, kr_answer 등 추가)
상황별 QnA 삽입 쿼리 수정 (공항 체크인, 입국 심사, 감기에 걸렸을 때 등 총 25개)

## 🔖 추가 변경 사항

choice_list JSON escape 처리
정답/오답 피드백 응답 구조 통일

## 🖥 작동하는 모습

질문 출력 → 보기 선택 → 정답 시 다음 질문, 오답 시 피드백 표시
(Postman 및 프론트에서 테스트 완료)

## 📚 관련 문서

없음
