### PR TITLE
⛑️ edit edit user_id -> uuid

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,7 +20,7 @@ export class AuthService {
       throw new BadRequestException('Invalid credentials');
     }
 
-    const payload = { email: user.email, sub: user.user_id };
+    const payload = { email: user.email, uuid: user.uuid, };
     return this.jwtService.sign(payload, {
       secret : process.env.JWT_REFRESH_SECRET,
       expiresIn: process.env.JWT_REFRESH_EXPIRES_IN, // 리프레시 토큰 유효기간 7일
@@ -29,7 +29,7 @@ export class AuthService {
 
   //구글 엑세스 발급 로직 
   async googleToken(user:User): Promise<string> {
-    const payload = { email: user.email, sub: user.user_id};
+    const payload = { email: user.email, uuid: user.uuid,};
     return this.jwtService.sign(payload, {
       secret : process.env.JWT_SECRET,
       expiresIn: process.env.JWT_EXPIRES_IN, // 엑세스 토큰 유효기간 15분
@@ -38,7 +38,7 @@ export class AuthService {
 
   //구글 리프레쉬 발급 로직 
   async googleRefreshToken(user:User): Promise<string> {
-    const payload = { email: user.email, sub: user.user_id};
+    const payload = { email: user.email, uuid: user.uuid,};
     return this.jwtService.sign(payload, {
       secret : process.env.JWT_REFRESH_SECRET,
       expiresIn: process.env.JWT_REFRESH_EXPIRES_IN, // 리프레시 토큰 유효기간 7일
@@ -52,10 +52,10 @@ export class AuthService {
         secret: process.env.JWT_REFRESH_SECRET,
       });
   
-      const user = await this.userRepository.findOneBy({ user_id: decoded.sub });
+      const user = await this.userRepository.findOneBy({ uuid: decoded.uuid });
       if (!user) throw new BadRequestException('User not found');
   
-      const payload = { email: user.email, sub: user.user_id };
+      const payload = { email: user.email, uuid: user.uuid, };
       const accessToken = this.jwtService.sign(payload, {
         secret: process.env.JWT_SECRET,
         expiresIn: process.env.JWT_EXPIRES_IN,
@@ -91,7 +91,7 @@ export class AuthService {
       throw new BadRequestException('Invalid credentials');
     }
   
-    const payload = { email: user.email, sub: user.user_id };
+    const payload = { email: user.email, sub: user.uuid };
     return this.jwtService.sign(payload, { // 여기서 엑세스 토큰 만들고 리턴했음
       secret : process.env.JWT_SECRET,
       expiresIn: process.env.JWT_EXPIRES_IN, // 엑세스 토큰 유효기간 15분

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: any) {
     // JWT payload 검증 후 사용자 정보를 반환
-    return { userId: payload.sub, email: payload.email };
+    return { uuid: payload.sub, email: payload.email };
   }
 }

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -9,7 +9,6 @@ export class CreateUserDto {
   @IsNotEmpty()
   password: string;
 
-  social_chek: number;
-
+  @IsNotEmpty()
   name: string;
 }

--- a/src/words/words.controller.ts
+++ b/src/words/words.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Delete, Get, Post, Body, Param, Request, BadRequestException  } from '@nestjs/common';
+import { Controller, Delete, Get, Post, Body, Param, Request, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { WordsService } from './words.service';
 import { Word } from './entities/words.entity';
 import { WordBook } from './entities/word-books.entity';
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('words')
 export class WordsController {
   constructor(private readonly wordsService: WordsService) {}
@@ -20,17 +22,13 @@ export class WordsController {
   // ✅ 단어장 생성 API
   @Post('/books')
   async createWordBook(@Request() req, @Body() body: { wordbook_title: string }) {
-    try {
-      return await this.wordsService.createWordBook(req.user.user_id, body.wordbook_title);
-    } catch (error) {
-      throw new BadRequestException(error.message);
-    }
+    return this.wordsService.createWordBook(req.user.uuid, body.wordbook_title);
   }
 
   // ✅ 단어장 조회 API
   @Get('/books')
   async getUserWordBooks(@Request() req): Promise<WordBook[]> {
-    return this.wordsService.getUserWordBooks(req.user.user_id);
+    return this.wordsService.getUserWordBooks(req.user.uuid);
   }
 
   // ✅ 단어장에 단어 추가(즐겨찾기) API
@@ -53,7 +51,7 @@ export class WordsController {
 
   // ✅ 단어장 삭제 API
   @Delete('/books/:wordbookId')
-  async deleteWordBook(@Param('wordbookId') wordbookId: number): Promise<void> {
-    return this.wordsService.deleteWordBook(wordbookId);
+  async deleteWordBook(@Param('wordbookId') wordbookId: number, @Request() req): Promise<void> {
+    return this.wordsService.deleteWordBook(wordbookId, req.user.uuid);
   } 
 }


### PR DESCRIPTION
## 🔍 해결하려는 문제

사용자 인증을 JWT 기반으로 처리하여 user_id 대신 uuid를 이용한 보안 강화.
사용자의 단어장 생성, 조회, 단어 추가/삭제 등의 API를 JWT 토큰 기반 인증 흐름으로 통합하기 위함.

## ✨ 주요 변경 사항
1. JWT 토큰 Payload에 uuid 포함 (sub에 uuid 저장)
2. JwtStrategy의 validate()에서 payload.sub를 uuid로 해석하도록 수정
3. 서비스 계층에서 user_id 대신 uuid로 사용자 조회하도록 로직 변경
4. 단어장 관련 API (생성, 조회, 추가, 삭제)에 @UseGuards(AuthGuard('jwt')) 적용
5. req.user.uuid를 통해 사용자 식별
6. Postman 테스트를 위한 JWT 토큰 기반 요청 흐름 점검 완료

## 🔖 추가 변경 사항

모든 단어 조회 API도 @UseGuards 씌움

## 🖥 작동하는 모습

✅ 회원가입 후 JWT 토큰 발급
✅ 토큰 기반 단어장 생성 및 조회
✅ 단어장에 단어 추가 및 삭제
✅ 단어장 자체 삭제
📸 Postman 테스트 성공 스크린샷 첨부 완료

## 📚 관련 문서

(https://www.notion.so/1c20782cdf9e8020bbd6eae8448d27eb)
