### PR TITLE
Feat/chatbot

### DIFF
--- a/src/chatbot/chatbot.controller.ts
+++ b/src/chatbot/chatbot.controller.ts
@@ -16,13 +16,14 @@ export class ChatbotController {
     private readonly chatQnAService: ChatQnAService 
   ) {}
 
-  // 🔥 제미니 챗봇 관련
+  // 🔥 제미나이 챗봇 관련
   @Post('text-chat')
   async textChat(@Body('message') message: string) {
-    const response = await this.chatbotService.generateResponse(message);
+    const response = await this.chatbotService.testGenerateResponse(message);
     return { reply: response };
   }
 
+  // ✅ 제미나이 API 연결 테스트
   @Post('voice-chat')
   @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() })) // ✅ 메모리 저장 방식 사용
   async voiceChat(@UploadedFile() file: Express.Multer.File, @Res() res: Response) {
@@ -38,7 +39,7 @@ export class ChatbotController {
       console.log(`📝 변환된 텍스트: ${text}`);
 
       // 2. AI 응답 생성 (Gemini API)
-      const aiResponse = await this.chatbotService.generateResponse(text);
+      const aiResponse = await this.chatbotService.testGenerateResponse(text);
       console.log(`🤖 AI 응답: ${aiResponse}`);
 
       // 3. 응답을 음성으로 변환 (TTS)
@@ -50,6 +51,90 @@ export class ChatbotController {
     } catch (error) {
       console.error('❌ 음성 챗봇 오류:', error);
       res.status(500).json({ error: '음성 챗봇 처리 중 오류 발생' });
+    }
+  }
+
+  // ✅ first 챗봇 시작
+  @Post('start')
+  async startConversation(@Body() body: { situation: string }) {
+    try {
+      const { situation } = body;
+      // 1. 상황 기반 프롬프트 구성
+      const prompt = `
+      状況: ${situation}
+      あなたはその状況における専門家です。ユーザーは${situation}の場面にいる人です。
+      以下のルールに従って自然なロールプレイを始めてください。
+      - 会話は現実のやり取りのように丁寧かつ自然に
+      - 1回に1~2文で会話を進める
+      - 質問を投げたら、ユーザーの回答を 待ってから次に進む
+      まずはあなたから会話を始めてください。
+      `;
+
+      // 2. Gemini 응답
+      const geminiText = await this.chatbotService.generateResponse(prompt);
+
+      // 3. 세션 시작
+      this.chatbotService.startSession(geminiText);
+
+      // 4. TTS 음성 변환
+      const audioPath = `output_${Date.now()}.mp3`;
+      await this.textToSpeechService.synthesizeSpeech(geminiText, audioPath);
+
+      // 5. 응답
+      return {
+        text: geminiText,
+        audioUrl: `/audio/${audioPath}`, // 프론트에서 static 경로로 접근
+      };
+    } catch (err) {
+      console.error('❌ 대화 시작 오류:', err);
+      return { error: '대화 시작 중 오류 발생' };
+    }
+  }
+
+  // ✅ continue 챗봇 이어가기
+  @Post('continue')
+  async continueConversation(@Body() body: { userText: string; situation: string }) {
+    try {
+      const { userText, situation } = body;
+
+      // 1. 유저 메시지를 메모리에 저장
+      this.chatbotService.appendUserMessage(userText);
+
+      // 2. 상황 프롬프트를 포함한 contextPrompt 생성
+      const contextPrompt = `
+        あなたは今「${situation}」という状況で、ユーザーとロールプレイを続けています。
+        これまでの会話を踏まえて、次の自然な一言を話してください。
+      `;
+
+      // 3. 챗봇 응답 받기 (contextPrompt 포함)
+      const geminiText = await this.chatbotService.continueConversation(contextPrompt);
+
+      // 4. 메모리에 챗봇 응답 저장
+      this.chatbotService.appendGeminiMessage(geminiText);
+
+      // 5. TTS 변환
+      const audioPath = `output_${Date.now()}.mp3`;
+      await this.textToSpeechService.synthesizeSpeech(geminiText, audioPath);
+
+      return {
+        text: geminiText,
+        audioUrl: `/audio/${audioPath}`,
+      };
+    } catch (error) {
+      console.error('❌ 대화 이어가기 오류:', error);
+      return { error: '대화 이어가기 중 오류 발생' };
+    }
+  }
+
+  // ✅ feedback 받기
+  @Post('feedback')
+  async getFeedback() {
+    try {
+      const feedback = await this.chatbotService.generateFeedback();
+      return { feedback };
+    } catch (err) {
+      console.error('❌ 피드백 생성 오류:', err);
+      return { error: '피드백 생성 중 오류 발생' };
     }
   }
 

--- a/src/chatbot/chatbot.controller.ts
+++ b/src/chatbot/chatbot.controller.ts
@@ -23,7 +23,7 @@ export class ChatbotController {
     return { reply: response };
   }
 
-  // ✅ 제미나이 API 연결 테스트
+  // ✅ 제미나이 API 연결 테스트 (음성 입력 → 텍스트 응답 → 음성 변환)
   @Post('voice-chat')
   @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() })) // ✅ 메모리 저장 방식 사용
   async voiceChat(@UploadedFile() file: Express.Multer.File, @Res() res: Response) {
@@ -58,8 +58,8 @@ export class ChatbotController {
   @Post('start')
   async startConversation(@Body() body: { situation: string }) {
     try {
-      const { text, audioUrl } = await this.chatbotService.startConversation(body.situation);
-      return { text, audioUrl };
+      const { text } = await this.chatbotService.startConversation(body.situation);
+      return { text };
     } catch (err) {
       console.error('❌ 대화 시작 오류:', err);
       return { error: '대화 시작 중 오류 발생' };
@@ -70,8 +70,8 @@ export class ChatbotController {
   @Post('continue')
   async continueConversation(@Body() body: { situation: string; userText: string }) {
     try {
-      const { text, audioUrl } = await this.chatbotService.continueConversation(body.situation, body.userText);
-      return { text, audioUrl };
+      const { text } = await this.chatbotService.continueConversation(body.situation, body.userText);
+      return { text };
     } catch (error) {
       console.error('❌ 대화 이어가기 오류:', error);
       return { error: '대화 이어가기 중 오류 발생' };

--- a/src/chatbot/chatbot.service.ts
+++ b/src/chatbot/chatbot.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
-import { SpeechToTextService } from './speech-to-text.service';
-import { TextToSpeechService } from './text-to-speech.service';
+// import { SpeechToTextService } from './speech-to-text.service';
+// import { TextToSpeechService } from './text-to-speech.service';
 
 type Message = { role: 'user' | 'gemini'; text: string };
 
@@ -10,24 +10,17 @@ type Message = { role: 'user' | 'gemini'; text: string };
 export class ChatbotService {
   private readonly apiKey: string;
   private readonly apiUrl = 'https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash-lite:generateContent';  
-  
-  // ✅ 메모리 세션 저장소 (Gemini API 형식용)
-  // private sessions: Map<string, { role: 'user' | 'model'; parts: { text: string } }[]> = new Map();
-  // ✅ 내부 로직용 간단한 텍스트 기반 세션 저장소
-  // private sessionMemory: Record<string, Message[]> = {};
-  // ✅ sessionId 제거 → 하나의 고정 세션 사용
   private conversationHistory: Message[] = [];
 
-  // 🔥 제미나이 챗봇 관련
   constructor(
     private readonly configService: ConfigService,
-    private readonly speechToTextService: SpeechToTextService,
-    private readonly textToSpeechService: TextToSpeechService
+    // private readonly speechToTextService: SpeechToTextService,
+    // private readonly textToSpeechService: TextToSpeechService
   ) {
     this.apiKey = this.configService.get<string>('GEMINI_API_KEY') ?? '';
   }
 
-  // ✅ 제미나이 API 연결 테스트
+  // ✅ 단일 메시지 테스트용
   async testGenerateResponse(prompt: string): Promise<string> {
     try {
       const response = await axios.post(
@@ -41,24 +34,14 @@ export class ChatbotService {
       console.error('Gemini API 요청 오류:', error.response?.data || error.message);
       throw new Error('Google Gemini API 호출 실패');
     }
-  } 
-
-  // ✅ 단일 응답 생성
-  async generateResponse(prompt: string): Promise<string> {
-    const response = await axios.post(
-      `${this.apiUrl}?key=${this.apiKey}`,
-      { contents: [{ parts: [{ text: prompt }] }] },
-      { headers: { 'Content-Type': 'application/json' } },
-    );
-
-    return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '응답을 생성할 수 없습니다。';
   }
 
-  // ✅ 대화 시작 (시스템 메시지 기반 초기화)
-  async startConversation(situation: string): Promise<{ text: string; audioUrl: string }> {
+  // ✅ 텍스트 챗봇 - 시작
+  async startConversation(situation: string): Promise<{ text: string /*, audioUrl: string */ }> {
     const prompt = `
       状況: ${situation}
       あなたはこの状況に登場する専門家です。ユーザーはその状況にいる人です。
+      
       以下のルールに従ってロールプレイを始めてください。
       - 「はい」「承知しました」などの定型句は一切使わないでください。
       - 会話は1ターンずつ交互に続ける（1〜2文以内）
@@ -71,25 +54,27 @@ export class ChatbotService {
     const geminiText = await this.generateResponse(prompt);
     this.conversationHistory = [{ role: 'gemini', text: geminiText }];
 
-    const audioPath = `output_${Date.now()}.mp3`;
-    await this.textToSpeechService.synthesizeSpeech(geminiText, audioPath);
-    const audioUrl = `/audio/${audioPath}`;
+    // const audioPath = `output_${Date.now()}.mp3`;
+    // await this.textToSpeechService.synthesizeSpeech(geminiText, audioPath);
+    // const audioUrl = `/audio/${audioPath}`;
 
-    return { text: geminiText, audioUrl };
+    return { text: geminiText /*, audioUrl */ };
   }
 
-  // ✅ 대화 이어가기
-  async continueConversation(situation: string, userText: string): Promise<{ text: string; audioUrl: string }> {
+  // ✅ 텍스트 챗봇 - 이어가기
+  async continueConversation(situation: string, userText: string): Promise<{ text: string /*, audioUrl: string */ }> {
     this.conversationHistory.push({ role: 'user', text: userText });
-  
+
     const contextPrompt = `
-      現在の状況は「${situation}」です。
-      状況に合った自然な一文を返してください。
-      会話は短く、1〜2文以内で交互に進めてください。
-      ユーザーの返答が状況に合わない場合は、優しく指摘して正しい流れに戻してください。
-      マークダウンや記号（**など）を使わないでください。プレーンな日本語で返してください。
+    あなたは「${situation}」における専門家として、ユーザーとロールプレイを続けています。
+    
+    以下のルールに従って次の応答を生成してください。
+    - 応答は現実の会話のように自然に
+    - 必ず1〜2文以内で返答すること
+    - ユーザーが状況に合わないことを言った場合は、「その質問はこの状況には関係がないようです」などで丁寧に軌道修正すること
+    - 記号（**、-、#など）やマークダウンは使わず、プレーンな日本語だけで返すこと
     `;
-  
+
     const promptContent = [
       { role: 'user', parts: [{ text: contextPrompt }] },
       ...this.conversationHistory.map(msg => ({
@@ -97,21 +82,21 @@ export class ChatbotService {
         parts: [{ text: msg.text }],
       })),
     ];
-  
+
     const response = await axios.post(
       `${this.apiUrl}?key=${this.apiKey}`,
       { contents: promptContent },
-      { headers: { 'Content-Type': 'application/json' } },
+      { headers: { 'Content-Type': 'application/json' } }
     );
-  
+
     const geminiText = response.data.candidates?.[0]?.content?.parts?.[0]?.text || '応答生成失敗';
     this.conversationHistory.push({ role: 'gemini', text: geminiText });
-  
-    const audioPath = `output_${Date.now()}.mp3`;
-    await this.textToSpeechService.synthesizeSpeech(geminiText, audioPath);
-    const audioUrl = `/audio/${audioPath}`;
-  
-    return { text: geminiText, audioUrl };
+
+    // const audioPath = `output_${Date.now()}.mp3`;
+    // await this.textToSpeechService.synthesizeSpeech(geminiText, audioPath);
+    // const audioUrl = `/audio/${audioPath}`;
+
+    return { text: geminiText /*, audioUrl */ };
   }
 
   // ✅ 피드백 생성
@@ -120,14 +105,21 @@ export class ChatbotService {
 
     const prompt = `
     以下は日本語学習者の会話の例です。
-    1文ずつ以下の3点を確認してください。
+    各文に対して、以下の3点を確認してください。
     1. 文法の誤りがないか
     2. 単語の使い方が適切か
     3. 状況に合った自然な発言か
 
-    問題があれば具体的にどこがどう間違っているかを説明してください。
-    問題がなければ「良い表現です」と述べた上で、なぜ良いのか簡単に説明してください。
-    マークダウンや記号（**など）を使わないでください。プレーンな日本語で返してください。
+    各文に対して、以下のフォーマットで簡潔にフィードバックしてください：
+
+    例）  
+    1. 「〜」→「良い表現です。理由：丁寧で自然な表現です。」  
+    2. 「〜」→「文法ミスがあります。理由：「〜」は不自然な使い方です。」
+
+    注意事項：  
+    - 特に「状況に合っているかどうか」を重視してください。  
+    - 記号（**、-、#など）やマークダウンを使わないでください。  
+    - 出力はすべてプレーンな日本語で返してください。
 
     ${userTexts.map((t, i) => `${i + 1}. ${t}`).join('\n')}
     `;
@@ -139,5 +131,16 @@ export class ChatbotService {
     );
 
     return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '피드백 생성 실패';
+  }
+
+  // ✅ 기본 응답 함수
+  async generateResponse(prompt: string): Promise<string> {
+    const response = await axios.post(
+      `${this.apiUrl}?key=${this.apiKey}`,
+      { contents: [{ parts: [{ text: prompt }] }] },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+
+    return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '응답을 생성할 수 없습니다。';
   }
 }

--- a/src/chatbot/chatbot.service.ts
+++ b/src/chatbot/chatbot.service.ts
@@ -2,17 +2,27 @@ import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
 
+type Message = { role: 'user' | 'gemini'; text: string };
+
 @Injectable()
 export class ChatbotService {
   private readonly apiKey: string;
   private readonly apiUrl = 'https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash-lite:generateContent';
+  // ✅ 메모리 세션 저장소 (Gemini API 형식용)
+  // private sessions: Map<string, { role: 'user' | 'model'; parts: { text: string } }[]> = new Map();
+  // ✅ 내부 로직용 간단한 텍스트 기반 세션 저장소
+  // private sessionMemory: Record<string, Message[]> = {};
 
-  // 🔥 제미니 챗봇 관련
+  // ✅ sessionId 제거 → 하나의 고정 세션 사용
+  private conversationHistory: Message[] = [];
+
+  // 🔥 제미나이 챗봇 관련
   constructor(private readonly configService: ConfigService) {
     this.apiKey = this.configService.get<string>('GEMINI_API_KEY') ?? '';
   }
 
-  async generateResponse(prompt: string): Promise<string> {
+  // ✅ 제미나이 API 연결 테스트
+  async testGenerateResponse(prompt: string): Promise<string> {
     try {
       const response = await axios.post(
         `${this.apiUrl}?key=${this.apiKey}`,
@@ -21,6 +31,120 @@ export class ChatbotService {
       );
 
       return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '응답을 생성할 수 없습니다.';
+    } catch (error) {
+      console.error('Gemini API 요청 오류:', error.response?.data || error.message);
+      throw new Error('Google Gemini API 호출 실패');
+    }
+  } 
+
+  // ✅ 세션 초기화 (Gemini 대화 컨텍스트용)
+  /* initSession(sessionId: string, systemPrompt: string) {
+    this.sessions.set(sessionId, [{ role: 'user', parts: { text: systemPrompt } }]);
+  }
+
+  saveUserMessage(sessionId: string, text: string) {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.push({ role: 'user', parts: { text } });
+    }
+  }
+
+  saveGeminiMessage(sessionId: string, text: string) {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.push({ role: 'model', parts: { text } });
+    }
+  } */
+  
+  // ✅ 텍스트 대화용 간단한 세션 로직
+  // 1. 첫 메시지 저장
+  startSession(geminiText: string) {
+    this.conversationHistory = [{ role: 'gemini', text: geminiText }];
+  }
+
+  // 2. 유저 메시지 추가
+  appendUserMessage(userText: string) {
+    this.conversationHistory.push({ role: 'user', text: userText });
+  }
+
+  // 3. Gemini 메시지 추가
+  appendGeminiMessage(geminiText: string) {
+    this.conversationHistory.push({ role: 'gemini', text: geminiText });
+  }
+
+  // 4. 제미니와 대화 이어가기
+  async continueConversation(contextPrompt: string): Promise<string> {
+    // 1. 상황 프롬프트 + 기존 대화 히스토리 병합
+    const promptContent = [
+      { role: 'user', parts: [{ text: contextPrompt }] },
+      ...this.conversationHistory.map(msg => ({
+        role: msg.role === 'user' ? 'user' : 'model',
+        parts: [{ text: msg.text }],
+      })),
+    ];
+  
+    // 2. Gemini API 호출
+    const response = await axios.post(
+      `${this.apiUrl}?key=${this.apiKey}`,
+      { contents: promptContent },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+  
+    // 3. Gemini 응답 추출 및 저장
+    const reply = response.data.candidates?.[0]?.content?.parts?.[0]?.text || '응답 생성 실패';
+    this.appendGeminiMessage(reply);
+    return reply;
+  }
+
+  // 5. 유저 메시지 리스트 추출
+  getUserMessages(): string[] {
+    return this.conversationHistory
+      .filter(msg => msg.role === 'user')
+      .map(msg => msg.text);
+  }
+
+  // 6. 피드백 생성
+  async generateFeedback(): Promise<string> {
+    const userTexts = this.getUserMessages();
+  
+    const prompt = `以下は日本語学習者の会話例です。\n1文ずつ文法や単語の使い方に問題があれば指摘してください。\n問題がなければ「良い表現です」とだけ伝えてください。\n\n${userTexts.map((text, i) => `${i + 1}. ${text}`).join('\n')}`;
+  
+    const response = await axios.post(
+      `${this.apiUrl}?key=${this.apiKey}`,
+      { contents: [{ parts: [{ text: prompt }] }] },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+  
+    return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '피드백 생성 실패';
+  }
+
+  // ✅ 전체 대화 기반 응답 생성
+  /* async continueWithContext(sessionId: string): Promise<string> {
+    const messages = this.sessions.get(sessionId);
+    if (!messages) {
+      throw new Error('세션을 찾을 수 없습니다.');
+    }
+
+    const response = await axios.post(
+      `${this.apiUrl}?key=${this.apiKey}`,
+      { contents: messages },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+
+    const reply = response.data.candidates?.[0]?.content?.parts?.[0]?.text || '응답을 생성할 수 없습니다.';
+    return reply;
+  } */
+
+  // ✨ 단일 메시지 전송용 기본 함수
+  async generateResponse(prompt: string): Promise<string> {
+    try {
+      const response = await axios.post(
+        `${this.apiUrl}?key=${this.apiKey}`,
+        { contents: [{ parts: [{ text: prompt }] }] },
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+
+      return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '응답을 생성할 수 없습니다。';
     } catch (error) {
       console.error('Gemini API 요청 오류:', error.response?.data || error.message);
       throw new Error('Google Gemini API 호출 실패');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,17 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { NestExpressApplication } from '@nestjs/platform-express'; // ✅ 추가
+import { join } from 'path'; // ✅ 추가
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, { logger: ['log', 'error', 'warn', 'debug', 'verbose'] });
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    logger: ['log', 'error', 'warn', 'debug', 'verbose'],
+  });
+
+  // ✅ 정적 파일 제공 설정 (mp3 등)
+  app.useStaticAssets(join(__dirname, '..'), {
+    prefix: '/audio/',
+  });
 
   app.enableCors({
     origin: 'http://localhost:3000',


### PR DESCRIPTION
## 🔍 해결하려는 문제

일본어 상황별 회화 연습을 위해, 사용자가 상황을 선택하고 Gemini 챗봇과 자연스러운 1:1 대화를 이어갈 수 있는 기능이 필요.
기존에는 챗봇 API 연결 테스트만 가능했고, 상황 기반 시나리오 흐름이 없었음.

.env에 GEMINI_API_KEY,  GOOGLE_API_KEY 필요 -> Kakao talk

## ✨ 주요 변경 사항

/chatbot/start: 상황을 기반으로 Gemini가 역할 설정 및 첫 질문을 생성하고 텍스트로 응답
/chatbot/continue: 사용자의 입력을 기반으로 이전 대화 흐름을 유지하며 Gemini가 응답 생성
/chatbot/feedback: 지금까지의 유저 입력에 대해 문법/단어/상황 적절성 등을 평가하는 피드백 생성
모든 응답은 마크다운 제거 및 1~2문장 기준으로 제어됨
음성 응답(TTS)은 현재 사용하지 않으며 코드에 주석 처리로 유지

## 🔖 추가 변경 사항

대화 흐름을 메모리(conversationHistory)에 저장하는 구조로 변경
음성 응답(TTS) 및 오디오 URL은 나중에 사용할 수 있도록 주석 처리함
피드백 프롬프트를 자연스럽고 구체적인 설명이 포함되도록 개선

docker-compose.yml에 수정할 부분
environment:
      - DB_HOST=${DB_HOST}
      - DB_PORT=${DB_PORT}
      - DB_USERNAME=${DB_USERNAME}
      - DB_PASSWORD=${DB_PASSWORD}
      - DB_DATABASE=${DB_DATABASE}
      - GEMINI_API_KEY=${GEMINI_API_KEY}
      - OPENAI_API_KEY=${OPENAI_API_KEY}
      - GOOGLE_API_KEY=${GOOGLE_API_KEY}

## 🖥 작동하는 모습

API 응답 이미지
(https://www.notion.so/API-1a50782cdf9e8010b0adf43570e22edc)

## 📚 관련 문서

Chatbot API 정리 표
(https://www.notion.so/API-1a50782cdf9e8010b0adf43570e22edc)
