### PR TITLE
✨ feat: add grammar zip

### DIFF
--- a/src/grammars/entities/grammar-books.entity.ts
+++ b/src/grammars/entities/grammar-books.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, JoinColumn, Column, ManyToOne, OneToMany } from 'typeorm';
 import { User } from '../../user/entity/user.entity';
 import { GrammarMiddle } from './grammar-middle.entity';
 
@@ -8,6 +8,7 @@ export class GrammarBook {
   grammarbook_id: number;
 
   @ManyToOne(() => User, (user) => user.grammar_books, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: "user_id" })
   user: User;
 
   @Column({ type: 'varchar', length: 30 })

--- a/src/grammars/entities/grammar-middle.entity.ts
+++ b/src/grammars/entities/grammar-middle.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, Column } from 'typeorm';
 import { Grammar } from './grammars.entity';
 import { GrammarBook } from './grammar-books.entity';
 
@@ -8,9 +8,11 @@ export class GrammarMiddle {
   grammar_middle_id: number;
 
   @ManyToOne(() => Grammar, (grammar) => grammar.grammar_middle, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: "grammar_id" })
   grammar: Grammar;
 
   @ManyToOne(() => GrammarBook, (grammarBook) => grammarBook.grammar_middle, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: "grammarbook_id" })
   grammarbook: GrammarBook;
 
   @Column({ type: 'date' })

--- a/src/grammars/grammars.controller.ts
+++ b/src/grammars/grammars.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Delete, Get, Post, Body, Param, Request, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { GrammarsService } from './grammars.service';
 import { Grammar } from './entities/grammars.entity';
 import { GrammarBook } from './entities/grammar-books.entity';
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('grammars')
 export class GrammarsController {
   constructor(private readonly grammarsService: GrammarsService) {}
@@ -10,7 +12,44 @@ export class GrammarsController {
   // 🔥 문법 관련
   // ✅ 모든 문법 조회 API
   @Get()
-  async getAllWords(): Promise<Grammar[]> {
+  async getAllGrammars(): Promise<Grammar[]> {
     return this.grammarsService.findAll();
+  }
+
+  // 🔥 문법장 관련
+  // ✅ 문법장 생성 API
+  @Post('/books')
+  async createGrammarBook(@Request() req, @Body() body: { grammarbook_title: string }) {
+    return this.grammarsService.createGrammarBook(req.user.uuid, body.grammarbook_title)
+  }
+
+  // ✅ 문법장 조회 API
+  @Get('/books')
+  async getUserGrammarBooks(@Request() req): Promise<GrammarBook[]> {
+    return this.grammarsService.getUserGrammarBooks(req.user.uuid);
+  }
+  
+  // ✅ 문법장에 문법 추가(즐겨찾기) API
+  @Post('/books/:grammarbookId/grammars')
+  async addGrammarToGrammarBook(
+    @Param('grammarbookId') grammarbookId: number,
+    @Body() body: { grammar_id: number }
+  ): Promise<void> {
+    return this.grammarsService.addGrammarToGrammarBook(grammarbookId, body.grammar_id);
+  }
+  
+  // ✅ 문법장에 문법 제거(즐겨찾기 해제) API
+   @Delete('/books/:grammarbookId/grammars/:grammarId')
+   async removeGrammarFromGrammarBook(
+    @Param('grammarbookId') grammarbookId: number,
+    @Param('grammarId') grammarId: number
+  ): Promise<void> {
+    return this.grammarsService.removeGrammarFromGrammarBook(grammarbookId, grammarId);
+  }
+  
+  // ✅ 문법장 삭제 API
+  @Delete('/books/:grammarbookId')
+  async deleteGrammarBook(@Param('grammarbookId') grammarbookId: number, @Request() req): Promise<void> {
+    return this.grammarsService.deleteGrammarBook(grammarbookId, req.user.uuid);
   }
 }

--- a/src/grammars/grammars.module.ts
+++ b/src/grammars/grammars.module.ts
@@ -5,9 +5,13 @@ import { GrammarMiddle } from './entities/grammar-middle.entity';
 import { GrammarBook } from './entities/grammar-books.entity';
 import { GrammarsService } from './grammars.service';
 import { GrammarsController } from './grammars.controller';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Grammar, GrammarMiddle, GrammarBook])],
+  imports: [
+    TypeOrmModule.forFeature([Grammar, GrammarMiddle, GrammarBook]),
+    UserModule,
+  ],
   providers: [GrammarsService],
   controllers: [GrammarsController],
   exports: [GrammarsService]

--- a/src/grammars/grammars.service.ts
+++ b/src/grammars/grammars.service.ts
@@ -10,16 +10,125 @@ import { User } from 'src/user/entity/user.entity';
 export class GrammarsService {
   constructor(
     @InjectRepository(Grammar)
-    private grammarRepository: Repository<Grammar>,
-    @InjectRepository(Grammar)
+    private grammarsRepository: Repository<Grammar>,
+    @InjectRepository(GrammarMiddle)
     private grammarMiddleRepository: Repository<GrammarMiddle>,
-    @InjectRepository(Grammar)
+    @InjectRepository(GrammarBook)
     private grammarBookRepository: Repository<GrammarBook>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
   ) {}
 
   // 🔥 문법 관련 비즈니스 로직
   // ✅ 모든 문법 조회 로직(프론트에 넘겨줄 데이터)
   async findAll(): Promise<Grammar[]> {
-    return this.grammarRepository.find();
+    return this.grammarsRepository.find();
+  }
+
+  // 🔥 문법장 관련 비즈니스 로직
+  // ✅ 문법장 생성 로직
+  async createGrammarBook(userUuid: string, grammarbook_title: string): Promise<GrammarBook> {
+    // ✅ uuid로 user 조회
+    const user = await this.userRepository.findOne({ where: { uuid: userUuid } });
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.')
+    }
+
+    // ✅ 1. 같은 이름의 문법장이 있는지 검사
+    const existingBook = await this.grammarBookRepository.findOne({
+      where: { user: { user_id: user.user_id }, grammarbook_title },
+    });
+
+    if (existingBook) {
+      throw new Error('이미 같은 이름의 문법장이 존재합니다.');
+    }
+
+    // ✅ 2. 새 문법장 생성
+    const grammarBook = this.grammarBookRepository.create({ user, grammarbook_title });
+
+    // ✅ 3. 저장 후 반환
+    return await this.grammarBookRepository.save(grammarBook)
+  }
+
+  // ✅ 문법장 목록 조회 로직
+  async getUserGrammarBooks(userUuid: string): Promise<GrammarBook[]> {
+    // ✅ uuid로 user 조회
+    const user = await this.userRepository.findOne({ where: { uuid: userUuid } });
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.')
+    }
+
+    return this.grammarBookRepository.find({
+      where: { user: { user_id: user.user_id } },
+      relations: ['grammar_middle', 'grammar_middle.grammar'], // 문법장에 속한 단어도 같이 조회
+    })
+  }
+
+  // ✅ 문법장에 문법 추가(즐겨찾기) 로직
+  async addGrammarToGrammarBook(grammarbookId: number, grammarId: number): Promise<void> {
+    // 문법장과 문법 찾기
+    const grammarBook = await this.grammarBookRepository.findOne({ where: { grammarbook_id: grammarbookId } });
+    const grammar = await this.grammarsRepository.findOne({ where: { grammar_id: grammarId } });
+
+    if (!grammarBook || !grammar) {
+      throw new Error('문법장 또는 문법을 찾을 수 없습니다.')
+    }
+
+    // 이미 추가된 문법인지 확인
+    const alreadyExists = await this.grammarMiddleRepository.findOne({
+      where: {
+        grammarbook: { grammarbook_id: grammarbookId },
+        grammar: { grammar_id: grammarId}
+      },
+    });
+    
+    if (alreadyExists) {
+      throw new Error('이미 이 문법장에 추가된 문법입니다.');
+    }
+
+    // 중복이 아니라면 추가 진행
+    // 문법과 문법장을 연결하는 중간 테이블(WordMiddle) 객체 생성
+    const grammarMiddle = this.grammarMiddleRepository.create({
+      grammarbook: grammarBook,
+      grammar: grammar,
+      added_at: new Date(),
+    });
+
+    // DB에 저장
+    await this.grammarMiddleRepository.save(grammarMiddle)
+  }
+
+  // ✅ 문법장에 문법 제거(즐겨찾기 해제) 로직
+  async removeGrammarFromGrammarBook(grammarbookID: number, grammarId: number): Promise<void> {
+    // 특정 문법장 내 특정 문법을 삭제
+    await this.grammarMiddleRepository.delete({
+      grammarbook: { grammarbook_id: grammarbookID },
+      grammar: { grammar_id: grammarId },
+    });  
+  }
+
+  // ✅ 문법장 삭제 로직
+  async deleteGrammarBook(grammarbookId: number, userUuid: string): Promise<void> {
+    // ✅ uuid로 user 조회
+    const user = await this.userRepository.findOne({ where: { uuid: userUuid } });
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    const grammarBook = await this.grammarBookRepository.findOne({
+      where: { grammarbook_id: grammarbookId },
+      relations: ['user'],
+    });
+
+    if (!grammarBook) {
+      throw new Error('문법장을 찾을 수 없습니다.');
+    }
+
+    if (grammarBook.user.user_id !== user.user_id) {
+      throw new Error('본인의 문법장만 삭제할 수 있습니다.');
+    }
+
+    // 특정 문법장 삭제 (문법장에 연결된 문법들도 `CASCADE`로 자동 삭제)
+    await this.grammarBookRepository.remove(grammarBook);
   }
 }

--- a/src/migrations/1744295640558-refactorgrammarentity.ts
+++ b/src/migrations/1744295640558-refactorgrammarentity.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Refactorgrammarentity1744295640558 implements MigrationInterface {
+    name = 'Refactorgrammarentity1744295640558'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP FOREIGN KEY \`FK_001103f0c7742cff4c5605d6e01\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP FOREIGN KEY \`FK_ab90a2fa57e45627c57b491a65a\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_books\` DROP FOREIGN KEY \`FK_edabcada86205b5ccc32860407e\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_books\` CHANGE \`userUserId\` \`user_id\` int NULL`);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP COLUMN \`grammarbookGrammarbookId\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP COLUMN \`grammarGrammarId\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD \`grammar_id\` int NULL`);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD \`grammarbook_id\` int NULL`);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD CONSTRAINT \`FK_b833d81b4b7a0b5f3638fb72790\` FOREIGN KEY (\`grammar_id\`) REFERENCES \`grammars\`(\`grammar_id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD CONSTRAINT \`FK_1a6473dae167166fde1fdfc30e1\` FOREIGN KEY (\`grammarbook_id\`) REFERENCES \`grammar_books\`(\`grammarbook_id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`grammar_books\` ADD CONSTRAINT \`FK_98716dd7ab7746eed3604c9b4c4\` FOREIGN KEY (\`user_id\`) REFERENCES \`user\`(\`user_id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`grammar_books\` DROP FOREIGN KEY \`FK_98716dd7ab7746eed3604c9b4c4\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP FOREIGN KEY \`FK_1a6473dae167166fde1fdfc30e1\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP FOREIGN KEY \`FK_b833d81b4b7a0b5f3638fb72790\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP COLUMN \`grammarbook_id\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` DROP COLUMN \`grammar_id\``);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD \`grammarGrammarId\` int NULL`);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD \`grammarbookGrammarbookId\` int NULL`);
+        await queryRunner.query(`ALTER TABLE \`grammar_books\` CHANGE \`user_id\` \`userUserId\` int NULL`);
+        await queryRunner.query(`ALTER TABLE \`grammar_books\` ADD CONSTRAINT \`FK_edabcada86205b5ccc32860407e\` FOREIGN KEY (\`userUserId\`) REFERENCES \`user\`(\`user_id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD CONSTRAINT \`FK_ab90a2fa57e45627c57b491a65a\` FOREIGN KEY (\`grammarGrammarId\`) REFERENCES \`grammars\`(\`grammar_id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`grammar_middle\` ADD CONSTRAINT \`FK_001103f0c7742cff4c5605d6e01\` FOREIGN KEY (\`grammarbookGrammarbookId\`) REFERENCES \`grammar_books\`(\`grammarbook_id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+}


### PR DESCRIPTION
## 🔍 해결하려는 문제

사용자별 문법장을 생성하고, 문법을 즐겨찾기 형태로 추가/삭제하며 관리할 수 있도록 문법장 CRUD 및 즐겨찾기 로직을 구현함.
JWT 기반 인증을 통해 로그인된 사용자만 접근 가능하도록 보호하고, 사용자 식별을 위해 uuid를 사용.

## ✨ 주요 변경 사항

GrammarsService에 문법장 생성, 조회, 문법 추가/제거, 삭제 기능 구현
@UseGuards(AuthGuard('jwt')) 적용으로 JWT 인증 기반 보호
req.user.uuid를 통해 사용자 식별 후 단어/문법장 데이터 처리
Postman을 이용해 단계별 API 테스트 완료
1. 문법 전체 조회
2. 문법장 생성 및 목록 조회
3. 문법장에 문법 추가/삭제
4. 문법장 삭제

## 🔖 추가 변경 사항

없음

## 🖥 작동하는 모습

grammar zip postman test
(https://www.notion.so/1d20782cdf9e807e9ef3ecfacf94986a)

## 📚 관련 문서

API 관련
(https://www.notion.so/API-1a50782cdf9e8010b0adf43570e22edc)
DB 관련
https://www.notion.so/DB-1960782cdf9e8011a4ade734bf74c584
