### PR TITLE
♻️ refactor: word entity word_quiz type refactor

### DIFF
--- a/src/migrations/1745197842370-wordentityrefactor.ts
+++ b/src/migrations/1745197842370-wordentityrefactor.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Wordentityrefactor1745197842370 implements MigrationInterface {
+    name = 'Wordentityrefactor1745197842370'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`words\` DROP COLUMN \`word_quiz\``);
+        await queryRunner.query(`ALTER TABLE \`words\` ADD \`word_quiz\` json NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`words\` DROP COLUMN \`word_quiz\``);
+        await queryRunner.query(`ALTER TABLE \`words\` ADD \`word_quiz\` text NULL`);
+    }
+
+}

--- a/src/words/entities/words.entity.ts
+++ b/src/words/entities/words.entity.ts
@@ -18,7 +18,7 @@ export class Word {
   @Column({ type: 'varchar', length: 10, nullable: true })
   word_level: string;
 
-  @Column({ type: 'simple-array', nullable: true })
+  @Column({ type: 'json', nullable: true })
   word_quiz: string[];
 
   @OneToMany(() => WordMiddle, (wordMiddle) => wordMiddle.word, { cascade: true, onDelete: 'CASCADE' })


### PR DESCRIPTION
## 🔍 해결하려는 문제

word_quiz컬럼의 date type이 text라 프론트에서 퀴즈게임 기능구현의 어려움 발생

## ✨ 주요 변경 사항

word entity의 word_quiz컬럼의 date type을 json으로 바꾸고 마이그레이션생성

## 🔖 추가 변경 사항

없음

## 🖥 작동하는 모습


## 📚 관련 문서

https://www.notion.so/DB-1960782cdf9e8011a4ade734bf74c584