### PR TITLE
✨ feat: 퀴즈게임 단어 불러오는 로직구현

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,7 +20,7 @@ export class AuthService {
       throw new BadRequestException('Invalid credentials');
     }
 
-    const payload = { email: user.email, uuid: user.uuid, };
+    const payload = { email: user.email, uuid: user.uuid, name: user.name };
     return this.jwtService.sign(payload, {
       secret : process.env.JWT_REFRESH_SECRET,
       expiresIn: process.env.JWT_REFRESH_EXPIRES_IN, // 리프레시 토큰 유효기간 7일
@@ -29,7 +29,7 @@ export class AuthService {
 
   //구글 엑세스 발급 로직 
   async googleToken(user:User): Promise<string> {
-    const payload = { email: user.email, uuid: user.uuid,};
+    const payload = { email: user.email, uuid: user.uuid, name: user.name};
     return this.jwtService.sign(payload, {
       secret : process.env.JWT_SECRET,
       expiresIn: process.env.JWT_EXPIRES_IN, // 엑세스 토큰 유효기간 15분
@@ -38,7 +38,7 @@ export class AuthService {
 
   //구글 리프레쉬 발급 로직 
   async googleRefreshToken(user:User): Promise<string> {
-    const payload = { email: user.email, uuid: user.uuid,};
+    const payload = { email: user.email, uuid: user.uuid, name: user.name};
     return this.jwtService.sign(payload, {
       secret : process.env.JWT_REFRESH_SECRET,
       expiresIn: process.env.JWT_REFRESH_EXPIRES_IN, // 리프레시 토큰 유효기간 7일
@@ -55,7 +55,7 @@ export class AuthService {
       const user = await this.userRepository.findOneBy({ uuid: decoded.uuid });
       if (!user) throw new BadRequestException('User not found');
   
-      const payload = { email: user.email, uuid: user.uuid, };
+      const payload = { email: user.email, uuid: user.uuid, name: user.name };
       const accessToken = this.jwtService.sign(payload, {
         secret: process.env.JWT_SECRET,
         expiresIn: process.env.JWT_EXPIRES_IN,
@@ -91,11 +91,12 @@ export class AuthService {
       throw new BadRequestException('Invalid credentials');
     }
   
-    const payload = { email: user.email, sub: user.uuid };
+    const payload = { email: user.email, sub: user.uuid, name: user.name };
     return this.jwtService.sign(payload, { // 여기서 엑세스 토큰 만들고 리턴했음
       secret : process.env.JWT_SECRET,
       expiresIn: process.env.JWT_EXPIRES_IN, // 엑세스 토큰 유효기간 15분
     });
+;
   }
 
 

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: any) {
     // JWT payload 검증 후 사용자 정보를 반환
-    return { uuid: payload.sub, email: payload.email };
+    return { uuid: payload.sub, email: payload.email, name: payload.name }; // 유저 프로필 정보에 name 추가 
   }
 }

--- a/src/quiz-game/quiz-game.controller.ts
+++ b/src/quiz-game/quiz-game.controller.ts
@@ -14,4 +14,9 @@ export class QuizGameController {
   async createRoom(@Body() body: { name: string }) {
     return this.quizgameservice.createRoom(body.name);
   }
+
+  @Get('/solo')
+  async getWords() {
+    return this.quizgameservice.getWords()
+  }
 }

--- a/src/quiz-game/quiz-game.module.ts
+++ b/src/quiz-game/quiz-game.module.ts
@@ -4,12 +4,14 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { QuizGameRoom, ChatRoomSchema } from './schemas/quiz-game.schema';
 import { QuizGameController } from './quiz-game.controller';
 import { QuizGameGateway } from './quiz-game.gateway';
+import { WordsModule } from 'src/words/words.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: QuizGameRoom.name, schema: ChatRoomSchema }
-    ])
+    ]),
+    WordsModule
   ],
   providers: [QuizGameGateway, QuizGameService],
   controllers: [QuizGameController],

--- a/src/quiz-game/quiz-game.service.ts
+++ b/src/quiz-game/quiz-game.service.ts
@@ -3,11 +3,16 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { QuizGameRoom } from './schemas/quiz-game.schema';
 import { v4 as uuidv4 } from 'uuid';
+import { InjectRepository } from '@nestjs/typeorm'; 
+import { Word } from 'src/words/entities/words.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class QuizGameService {
   constructor(
     @InjectModel(QuizGameRoom.name) private QuizGameRoomModel: Model<QuizGameRoom>,
+    @InjectRepository(Word)
+    private wordRepository: Repository<Word>,
   ) {}
 
   async createRoom(name: string): Promise<QuizGameRoom> {
@@ -79,5 +84,18 @@ export class QuizGameService {
         },
       },
     );
+  }
+  async getWords(): Promise<Word> { // 단어받을용ㅇㅇ
+    const word = await this.wordRepository
+    .createQueryBuilder('word')
+    .orderBy('RAND()')
+    .limit(1)
+    .getOne();
+
+    if (!word) {
+      throw new NotFoundException('단어 없다');
+    }
+
+    return word;
   }
 }

--- a/src/words/words.module.ts
+++ b/src/words/words.module.ts
@@ -14,6 +14,6 @@ import { UserModule } from 'src/user/user.module';
   ],
   providers: [WordsService],
   controllers: [WordsController],
-  exports: [WordsService],
+  exports: [WordsService,TypeOrmModule.forFeature([Word])],
 })
 export class WordsModule {}


### PR DESCRIPTION
## 🔍 해결하려는 문제

> 솔로게임에 필요한 단어 불러오는 로직 구현

## ✨ 주요 변경 사항

> jwt.strategy.ts 밸리데이터 payload에 유저 프로필을 위한 user.name담기게 했음.
   auth.service.ts 엑세스토큰 payload에 유저 프로필을 위한 user.name담기게 했음
   quiz-game.controller , module , service 단어 불러오는 로직 추가 
   words.module에 담긴 단어 내보낼수 있도록 export 구문 추가 (코드 보수성 향상 목표) 


## 🔖 추가 변경 사항

> 없음.

## 🖥 작동하는 모습

> 스크린샷, GIF 또는 비디오를 첨부해 변경된 부분을 보여주세요.

## 📚 관련 문서

> 관련된 Issue, 문서, 또는 노션 링크가 있다면 첨부해주세요.
