### PR TITLE
✨ feat: 단어를 전체를 받는거에서 레벨별로 불러 오게끔 변경

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -84,7 +84,7 @@ export class AuthController {
       httpOnly: false,       // 자바스크립트로 접근 불가옵션 (XSS 방지) 차후 jwt guards 보안 처리후 true로 리팩토링 예정 false는 원래 보안상 추천되지 않음(프론트에서 쿠키에 접근가능해짐)
       secure: false,        // HTTPS에서만 동작하려면 true (개발환경은 false)
       sameSite: 'lax',      // CSRF 방지
-      maxAge: 60 * 60 * 1000, // 1시간 (밀리초 단위)
+      maxAge: 15 * 60 * 1000, // 15분 (밀리초 단위)
       path: '/',
     });
 

--- a/src/quiz-game/quiz-game.controller.ts
+++ b/src/quiz-game/quiz-game.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query } from '@nestjs/common';
 import { QuizGameService } from './quiz-game.service';
 
 @Controller('api/rooms')
@@ -16,7 +16,7 @@ export class QuizGameController {
   }
 
   @Get('/solo')
-  async getWords() {
-    return this.quizgameservice.getWords()
+  async getWords(@Query('level') level?: string) { //원하는 레벨을 받을수 있게끔 수정 요청은 /solo?level=N1 이렇게
+    return this.quizgameservice.getWords(level);
   }
 }

--- a/src/quiz-game/quiz-game.service.ts
+++ b/src/quiz-game/quiz-game.service.ts
@@ -85,17 +85,16 @@ export class QuizGameService {
       },
     );
   }
-  async getWords(): Promise<Word> { // 단어받을용ㅇㅇ
-    const word = await this.wordRepository
-    .createQueryBuilder('word')
-    .orderBy('RAND()')
-    .limit(1)
-    .getOne();
-
+  async getWords(level?: string): Promise<Word> {
+    const query = this.wordRepository.createQueryBuilder('word');
+    if (level && ['N1', 'N2', 'N3', 'N4', 'N5'].includes(level)) {
+      query.where('word.word_level = :level', { level });
+    }
+    const word = await query.orderBy('RAND()').limit(1).getOne();
+  
     if (!word) {
       throw new NotFoundException('단어 없다');
     }
-
     return word;
   }
 }


### PR DESCRIPTION
## 🔍 해결하려는 문제

> 단어퀴즈에 사용되는 단어를 레벨 구분없이 전체 다 받아 오는걸 원하는 레벨에 맞게 받아 오게끔 변경
구글 로그인JWT 유지시간 수정

## ✨ 주요 변경 사항

> quiz-game.controller 요청시 받을api 변경
quiz-game.service 레벨에 맞게끔 DB에서 단어 가져오게 변경
auth.controller 구글 로그인시 JWT토큰 유지시간이기존 로직과 유지시간이 동일하지 않던 부분을 수정

## 🔖 추가 변경 사항

> 추가적으로 변경된 부분이 있으면 작성하고, 없으면 "없음"으로 작성해주세요.

## 🖥 작동하는 모습

> 
![단어](https://github.com/user-attachments/assets/638d6621-612a-4d52-be24-8712be3ac016)
.

## 📚 관련 문서

> https://www.notion.so/API-Login-Signup-Socket-1c70782cdf9e8086bf89c84ff25a9aeb
