### PR TITLE
✨ feat: word progress

### DIFF
--- a/src/migrations/1748395330390-wordprogress.ts
+++ b/src/migrations/1748395330390-wordprogress.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Wordprogress1748395330390 implements MigrationInterface {
+    name = 'Wordprogress1748395330390'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`word_progress\` (\`word_progress_id\` int NOT NULL AUTO_INCREMENT, \`learning_level\` varchar(10) NOT NULL, \`current_index\` int NOT NULL DEFAULT '0', \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`user_id\` int NULL, UNIQUE INDEX \`IDX_9d1d418851da1613144cd6dfa9\` (\`user_id\`, \`learning_level\`), PRIMARY KEY (\`word_progress_id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`word_progress\` ADD CONSTRAINT \`FK_9e5e83ab5443d8fc32355fe4eca\` FOREIGN KEY (\`user_id\`) REFERENCES \`user\`(\`user_id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`word_progress\` DROP FOREIGN KEY \`FK_9e5e83ab5443d8fc32355fe4eca\``);
+        await queryRunner.query(`DROP INDEX \`IDX_9d1d418851da1613144cd6dfa9\` ON \`word_progress\``);
+        await queryRunner.query(`DROP TABLE \`word_progress\``);
+    }
+
+}

--- a/src/words/entities/word-progress.entity.ts
+++ b/src/words/entities/word-progress.entity.ts
@@ -1,0 +1,22 @@
+import { Unique, Entity, PrimaryGeneratedColumn, Column, ManyToOne, UpdateDateColumn, JoinColumn } from 'typeorm';
+import { User } from '../../user/entity/user.entity';
+
+@Unique(['user', 'learning_level'])
+@Entity('word_progress')
+export class WordProgress {
+  @PrimaryGeneratedColumn()
+  word_progress_id: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: "user_id" })
+  user: User;
+
+  @Column({ type: 'varchar', length: 10 })
+  learning_level: string; // ex: 'JLPT N1', 'JLPT N2'
+
+  @Column({ type: 'int', default: 0 })
+  current_index: number; // 셔플 리스트에서의 위치
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/src/words/words.controller.ts
+++ b/src/words/words.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, Post, Body, Param, Request, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Post, Body, Param, Request, UseGuards, Query } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { WordsService } from './words.service';
 import { Word } from './entities/words.entity';
@@ -14,6 +14,34 @@ export class WordsController {
   @Get()
   async getAllWords(): Promise<Word[]> {
     return this.wordsService.findAll();
+  }
+
+  // ✅ 처음시작 & 이어보기 - 단어 데이터 & 진도 불러오기
+  @Get('/with-progress')
+  @UseGuards(AuthGuard('jwt'))
+  async getWordsWithProgress(
+    @Request() req,
+    @Query('learning_level') level: string
+  ) {
+    return this.wordsService.getWordsAndProgress(req.user.uuid, level);
+  }
+
+  // ✅ 진도 저장
+  @Post('/save-progress')
+  async saveProgress(
+    @Request() req,
+    @Body() body: { learning_level: string; current_index: number }
+  ) {
+    return this.wordsService.updateWordProgress(req.user.uuid, body.learning_level, body.current_index);
+  }
+
+  // ✅ 진도 리셋
+  @Delete('/reset-progress')
+  async resetProgress(
+    @Request() req,
+    @Query('learning_level') level: string
+  ): Promise<void> {
+    return this.wordsService.resetWordProgress(req.user.uuid, level);
   }
 
   // ❌ 특정 단어 검색 API

--- a/src/words/words.module.ts
+++ b/src/words/words.module.ts
@@ -6,10 +6,11 @@ import { WordMiddle } from './entities/word-middle.entity';
 import { WordsService } from './words.service';
 import { WordsController } from './words.controller';
 import { UserModule } from 'src/user/user.module';
+import { WordProgress } from './entities/word-progress.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Word, WordBook, WordMiddle]),
+    TypeOrmModule.forFeature([Word, WordBook, WordMiddle, WordProgress]),
     UserModule,
   ],
   providers: [WordsService],


### PR DESCRIPTION
## 🔍 해결하려는 문제

유저가 단어 학습 중 중단했다가 다시 돌아왔을 때, 이전에 보던 위치부터 이어서 볼 수 있도록 진도 정보를 저장 및 불러오는 기능이 없었음.
단어 레벨별(JLPT N5 등) 학습 위치를 기억해 이어보기 UX를 개선하고자 함.

## ✨ 주요 변경 사항

WordProgress 엔티티 및 테이블 생성 (유저 + 학습 레벨별 진도 관리)

GET /words/with-progress: 학습 레벨별 단어 리스트 + 이어보기 위치 반환

POST /words/save-progress: 학습 진행 상황 저장 (current_index)

DELETE /words/reset-progress: 특정 학습 레벨의 진도 초기화 기능 추가

WordsService, WordsController에 관련 비즈니스 로직 및 API 추가

word_level 기준 정렬된 단어 리스트 기반으로 프론트에서 이어보기 가능하도록 구조 설계

## 🔖 추가 변경 사항

WordProgress 엔티티 및 테이블 생성에 따른 마이그레이션 실행 필요
기존 전체 단어 불러오는 로직은 남겨놨는데 사용은 안함 -> 백엔드에서 단어레벨 필터링

## 🖥 작동하는 모습

참고자료의 Postman API TEST 확인바람

## 📚 관련 문서
참고자료
https://www.notion.so/25-05-30-2010782cdf9e80ae95f4f8efed3dfedd
단어 데이터
https://www.notion.so/DB-1960782cdf9e8011a4ade734bf74c584
