### PR TITLE
✨ feat: word one more button

### DIFF
--- a/src/migrations/1749047906799-addcustomword.ts
+++ b/src/migrations/1749047906799-addcustomword.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Addcustomword1749047906799 implements MigrationInterface {
+    name = 'Addcustomword1749047906799'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`word_progress\` ADD \`custom_word_ids\` json NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`word_progress\` DROP COLUMN \`custom_word_ids\``);
+    }
+
+}

--- a/src/words/entities/word-progress.entity.ts
+++ b/src/words/entities/word-progress.entity.ts
@@ -17,6 +17,9 @@ export class WordProgress {
   @Column({ type: 'int', default: 0 })
   current_index: number; // 셔플 리스트에서의 위치
 
+  @Column({ type: 'json', nullable: true })
+  custom_word_ids?: number[];
+
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/src/words/words.controller.ts
+++ b/src/words/words.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, Post, Body, Param, Request, UseGuards, Query } from '@nestjs/common';
+import { Controller, Delete, Get, Patch, Post, Body, Param, Request, UseGuards, Query } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { WordsService } from './words.service';
 import { Word } from './entities/words.entity';
@@ -18,7 +18,6 @@ export class WordsController {
 
   // ✅ 처음시작 & 이어보기 - 단어 데이터 & 진도 불러오기
   @Get('/with-progress')
-  @UseGuards(AuthGuard('jwt'))
   async getWordsWithProgress(
     @Request() req,
     @Query('learning_level') level: string
@@ -32,7 +31,11 @@ export class WordsController {
     @Request() req,
     @Body() body: { learning_level: string; current_index: number }
   ) {
-    return this.wordsService.updateWordProgress(req.user.uuid, body.learning_level, body.current_index);
+    return this.wordsService.updateWordProgress(
+      req.user.uuid,
+      body.learning_level,
+      body.current_index,
+    );
   }
 
   // ✅ 진도 리셋
@@ -44,6 +47,19 @@ export class WordsController {
     return this.wordsService.resetWordProgress(req.user.uuid, level);
   }
 
+  // ✅ 한번 더 버튼
+  @Patch('/repeat-word')
+  async repeatWord(
+    @Request() req,
+    @Body() body: { learning_level: string; offset: number }
+  ): Promise<void> {
+    return this.wordsService.repeatWord(
+      req.user.uuid,
+      body.learning_level,
+      body.offset,
+    );
+  }
+  
   // ❌ 특정 단어 검색 API
 
   // 🔥 단어장 관련


### PR DESCRIPTION
## 🔍 해결하려는 문제

유저가 단어 학습 중 특정 단어를 반복하고 싶은 경우, 해당 단어를 나중에 다시 등장시키는 기능이 없었음.
또한 유저의 학습 진도를 보다 유연하게 관리하기 위해 단어 순서를 유저 맞춤으로 설정할 수 있는 구조가 필요했음.

## ✨ 주요 변경 사항

- WordProgress에 custom_word_ids 컬럼 추가 (유저별 단어 순서 저장)

- repeatWord 기능 구현: 현재 단어를 N칸 뒤로 보내고 다음 단어로 진행

- getWordsAndProgress 로직 수정: custom_word_ids 기준으로 단어 정렬

- 진도 저장 시 custom_word_ids도 함께 업데이트되도록 변경

- repeatWord용 API (PATCH /words/repeat-word) 추가

## 🔖 추가 변경 사항

마이그레이션 파일 실행 필요
문서 참고 -> https://www.notion.so/1ba0782cdf9e80b4a8b3c3dbb767b255

## 🖥 작동하는 모습

![image](https://github.com/user-attachments/assets/0228bb16-0636-4d1b-b62d-acc36913637d)
(예: 단어 50번 → 한번 더 클릭 → 60번으로 이동, 나머지 당겨짐)

## 📚 관련 문서

API 관련
https://www.notion.so/25-06-05-2010782cdf9e80ae95f4f8efed3dfedd
DB 관련
https://www.notion.so/DB-1960782cdf9e8011a4ade734bf74c584
